### PR TITLE
Handle empty bucket on first upload. Allow specifying the endpoint_url for services other than S3 (like b2 and digitalocean spaces)

### DIFF
--- a/dogsheep_photos/utils.py
+++ b/dogsheep_photos/utils.py
@@ -43,8 +43,9 @@ def get_all_keys(client, bucket):
     paginator = client.get_paginator("list_objects_v2")
     keys = []
     for page in paginator.paginate(Bucket=bucket):
-        for row in page["Contents"]:
-            keys.append(row["Key"])
+        if "Contents" in page:
+            for row in page["Contents"]:
+                keys.append(row["Key"])
     return keys
 
 
@@ -118,8 +119,10 @@ def to_uuid(uuid_0, uuid_1):
 def s3_upload(path, sha256, ext, creds):
     client = getattr(boto3_local, "client", None)
     if client is None:
+        endpoint_url = creds["photos_s3_endpoint"] if "photos_s3_endpoint" in creds and creds["photos_s3_endpoint"] else None
         client = boto3.client(
             "s3",
+            endpoint_url=endpoint_url,
             aws_access_key_id=creds["photos_s3_access_key_id"],
             aws_secret_access_key=creds["photos_s3_secret_access_key"],
         )

--- a/tests/test_s3_auth.py
+++ b/tests/test_s3_auth.py
@@ -6,11 +6,12 @@ import json
 def test_s3_auth():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["s3-auth"], input="bucket\nxxx\nyyy\n")
+        result = runner.invoke(cli, ["s3-auth"], input="bucket\nxxx\nyyy\nendpoint")
         assert 0 == result.exit_code
         data = json.load(open("auth.json"))
         assert {
             "photos_s3_bucket": "bucket",
             "photos_s3_access_key_id": "xxx",
             "photos_s3_secret_access_key": "yyy",
+            "photos_s3_endpoint": "endpoint"
         } == data


### PR DESCRIPTION
Finally got around to trying dogsheep-photos but I want to use backblaze's b2 service instead of AWS S3.
Had to add a way to optionally specify the endpoint_url to connect to. Then with the bucket being empty the initial key retrieval would fail. Probably a better way to see that the bucket is empty than doing a test inside the paginator loop.

Also probably a better way to specify the endpoint_url as we get and test for it twice using the same code in two different places but did not want to spend too much time worrying about it.